### PR TITLE
Set module name to Github repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module rag-crawler
+module github.com/h2210316651/lexicrawler
 
 go 1.23
 


### PR DESCRIPTION
I'm not a Go expert myself, but I was surprised that I couldn't install this program from Github itself and had a chat with both Perplexity and ChatGPT. Both said that the convention in Go is to set the module name to the Github repo and that this should also allow directly installing from Github.